### PR TITLE
Filter live classes by requester role and packages

### DIFF
--- a/src/liveClasses/liveClasses.controller.ts
+++ b/src/liveClasses/liveClasses.controller.ts
@@ -10,7 +10,9 @@ import {
   HttpStatus,
   SetMetadata,
   Query,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { LiveClassesService } from './liveClasses.service';
 import { CreateLiveClassDto } from './dto/create-liveClass.dto';
@@ -67,14 +69,20 @@ export class LiveClassesController {
     @Query('page') page: number = 1,
     @Query('limit') limit: number = 10,
     @Query('search') search: string = '',
+    @Req() req: Request,
   ) {
     try {
+      const requester = req.user as
+        | { userId?: string; role?: string }
+        | undefined;
       const { liveClasses, total } =
         await this.liveClassesService.findAllWithPaging(
           institute,
           page,
           limit,
           search,
+          requester?.role,
+          requester?.userId,
         );
       return {
         status: HttpStatus.OK,
@@ -99,10 +107,20 @@ export class LiveClassesController {
     description: 'Count of upcoming live classes retrieved successfully',
   })
   @SetMetadata('permissions', ['view_live_classes'])
-  async getUpcomingLiveClassesCount(@Query('institute') institute: string) {
+  async getUpcomingLiveClassesCount(
+    @Query('institute') institute: string,
+    @Req() req: Request,
+  ) {
     try {
+      const requester = req.user as
+        | { userId?: string; role?: string }
+        | undefined;
       const count =
-        await this.liveClassesService.countUpcomingLiveClasses(institute);
+        await this.liveClassesService.countUpcomingLiveClasses(
+          institute,
+          requester?.role,
+          requester?.userId,
+        );
       return {
         status: HttpStatus.OK,
         message: 'Count of upcoming live classes retrieved successfully',

--- a/src/liveClasses/liveClasses.service.ts
+++ b/src/liveClasses/liveClasses.service.ts
@@ -4,12 +4,44 @@ import { Model } from 'mongoose';
 import { LiveClass } from './schemas/liveClass.schema';
 import { CreateLiveClassDto } from './dto/create-liveClass.dto';
 import { UpdateLiveClassDto } from './dto/update-liveClass.dto';
+import { User } from 'src/users/schemas/user.schema';
 
 @Injectable()
 export class LiveClassesService {
   constructor(
     @InjectModel(LiveClass.name) private liveClassModel: Model<LiveClass>,
+    @InjectModel(User.name) private userModel: Model<User>,
   ) {}
+
+  private async buildAudienceQuery(
+    institute: string,
+    role?: string,
+    userId?: string,
+  ): Promise<Record<string, any>> {
+    const query: Record<string, any> = {
+      institute,
+      isDeleted: { $ne: true },
+    };
+
+    if (role === 'student' && userId) {
+      const student = await this.userModel
+        .findById(userId)
+        .select('packages')
+        .lean();
+
+      const packageIds = Array.isArray(student?.packages)
+        ? student.packages.map((pkg: any) => pkg.toString())
+        : [];
+
+      if (packageIds.length === 0) {
+        query.package = { $in: [] };
+      } else {
+        query.package = { $in: packageIds };
+      }
+    }
+
+    return query;
+  }
 
   create(createLiveClassDto: CreateLiveClassDto): Promise<LiveClass> {
     const createdLiveClass = new this.liveClassModel(createLiveClassDto);
@@ -25,14 +57,16 @@ export class LiveClassesService {
     page: number,
     limit: number,
     search: string,
+    role?: string,
+    userId?: string,
   ) {
+    const baseQuery = await this.buildAudienceQuery(institute, role, userId);
     const query = search
       ? {
-          institute,
+          ...baseQuery,
           title: { $regex: search, $options: 'i' },
-          isDeleted: { $ne: true },
         }
-      : { institute, isDeleted: { $ne: true } };
+      : baseQuery;
     const liveClasses = await this.liveClassModel
       .find(query)
       .skip((page - 1) * limit)
@@ -106,12 +140,16 @@ export class LiveClassesService {
       .exec();
   }
 
-  async countUpcomingLiveClasses(institute: string): Promise<number> {
+  async countUpcomingLiveClasses(
+    institute: string,
+    role?: string,
+    userId?: string,
+  ): Promise<number> {
     const today = new Date();
+    const baseQuery = await this.buildAudienceQuery(institute, role, userId);
     const count = await this.liveClassModel
       .countDocuments({
-        institute,
-        isDeleted: { $ne: true },
+        ...baseQuery,
         date: { $gte: today },
       })
       .exec();


### PR DESCRIPTION
Pass the authenticated requester (role and userId) from the controller into the LiveClassesService for paging and counting. Inject the User model and add buildAudienceQuery to scope queries by institute and, for students, restrict classes to the student's package IDs (returns empty set if student has no packages). Update findAllWithPaging and countUpcomingLiveClasses to accept role/userId and use the built base query (preserving isDeleted handling and search filtering). This ensures students only see live classes intended for their enrolled packages.