### PR TITLE
Add Assignments module and CRUD endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { QuestionsModule } from './questions/questions.module';
 import { ResultsModule } from './results/results.module';
 import { QuestionResultsModule } from './question-results/question-results.module';
 import { LiveClassesModule } from './liveClasses/liveClasses.module';
+import { AssignmentsModule } from './assignments/assignments.module';
 import { ReportsModule } from './reports/reports.module'; // Import the new ReportsModule
 import { AnalyticsModule } from './analytics/analytics.module'; // Import AnalyticsModule
 import { SsoModule } from './sso/sso.module'; // Import SSO Module
@@ -134,6 +135,7 @@ if (!DB_URL) {
     ResultsModule,
     QuestionResultsModule,
     LiveClassesModule,
+    AssignmentsModule,
     ThreadsModule,
     DiscussionsModule,
     ChatModule, // Add ChatModule

--- a/src/assignments/assignments.controller.ts
+++ b/src/assignments/assignments.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpStatus,
+  SetMetadata,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiParam,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AssignmentsService } from './assignments.service';
+import { CreateAssignmentDto } from './dto/create-assignment.dto';
+
+@ApiTags('assignments')
+@Controller('assignments')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class AssignmentsController {
+  constructor(private readonly assignmentsService: AssignmentsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new assignment for a subject in a package' })
+  @ApiBody({ type: CreateAssignmentDto })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Assignment created successfully' })
+  @SetMetadata('permissions', ['edit_topics'])
+  async create(@Body() dto: CreateAssignmentDto) {
+    const assignment = await this.assignmentsService.create(dto);
+    return {
+      status: HttpStatus.OK,
+      message: 'Assignment created successfully',
+      data: assignment,
+    };
+  }
+
+  @Get('subject/:subjectId/package/:packageId')
+  @ApiOperation({ summary: 'Get all assignments for a subject in a package' })
+  @ApiParam({ name: 'subjectId', required: true })
+  @ApiParam({ name: 'packageId', required: true })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Assignments retrieved successfully' })
+  async findBySubjectAndPackage(
+    @Param('subjectId') subjectId: string,
+    @Param('packageId') packageId: string,
+  ) {
+    const assignments = await this.assignmentsService.findBySubjectAndPackage(
+      subjectId,
+      packageId,
+    );
+    return {
+      status: HttpStatus.OK,
+      message: 'Assignments retrieved successfully',
+      data: assignments,
+    };
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Soft-delete an assignment' })
+  @ApiParam({ name: 'id', required: true })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Assignment deleted successfully' })
+  @SetMetadata('permissions', ['edit_topics'])
+  async remove(@Param('id') id: string) {
+    const result = await this.assignmentsService.remove(id);
+    return {
+      status: HttpStatus.OK,
+      message: 'Assignment deleted successfully',
+      data: result,
+    };
+  }
+}

--- a/src/assignments/assignments.module.ts
+++ b/src/assignments/assignments.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AssignmentsController } from './assignments.controller';
+import { AssignmentsService } from './assignments.service';
+import { Assignment, AssignmentSchema } from './schemas/assignment.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Assignment.name, schema: AssignmentSchema },
+    ]),
+  ],
+  controllers: [AssignmentsController],
+  providers: [AssignmentsService],
+  exports: [AssignmentsService],
+})
+export class AssignmentsModule {}

--- a/src/assignments/assignments.service.ts
+++ b/src/assignments/assignments.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Assignment } from './schemas/assignment.schema';
+import { CreateAssignmentDto } from './dto/create-assignment.dto';
+
+@Injectable()
+export class AssignmentsService {
+  constructor(
+    @InjectModel(Assignment.name) private assignmentModel: Model<Assignment>,
+  ) {}
+
+  async create(dto: CreateAssignmentDto): Promise<Assignment> {
+    const created = new this.assignmentModel(dto);
+    return created.save();
+  }
+
+  async findBySubjectAndPackage(
+    subjectId: string,
+    packageId: string,
+  ): Promise<Assignment[]> {
+    return this.assignmentModel
+      .find({
+        subject: subjectId,
+        package: packageId,
+        isDeleted: { $ne: true },
+      })
+      .sort({ createdAt: -1 })
+      .exec();
+  }
+
+  async remove(id: string): Promise<{ deleted: true }> {
+    const existing = await this.assignmentModel
+      .findOne({ _id: id, isDeleted: { $ne: true } })
+      .lean();
+
+    if (!existing) {
+      throw new NotFoundException('Assignment not found');
+    }
+
+    await this.assignmentModel
+      .updateOne({ _id: id }, { isDeleted: true, deletedAt: new Date() })
+      .exec();
+
+    return { deleted: true };
+  }
+}

--- a/src/assignments/dto/create-assignment.dto.ts
+++ b/src/assignments/dto/create-assignment.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Types } from 'mongoose';
+
+export class CreateAssignmentDto {
+  @ApiProperty({ example: 'Chapter 1 Assignment' })
+  title: string;
+
+  @ApiProperty({ example: '60d0fe4f5311236168a109ca' })
+  subject: Types.ObjectId;
+
+  @ApiProperty({ example: '60d0fe4f5311236168a109cb' })
+  package: Types.ObjectId;
+
+  @ApiProperty({ example: '60d0fe4f5311236168a109cc' })
+  institute: Types.ObjectId;
+
+  @ApiProperty({
+    example: [
+      'https://example.com/assignment1.pdf',
+      'https://example.com/assignment2.docx',
+    ],
+    description: 'Array of file URLs (PDF, DOCX, XLSX, etc.)',
+  })
+  fileUrls: string[];
+}

--- a/src/assignments/schemas/assignment.schema.ts
+++ b/src/assignments/schemas/assignment.schema.ts
@@ -1,0 +1,32 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { Document } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Assignment extends Document {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Subject', required: true })
+  subject: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'Package', required: true })
+  package: mongoose.Schema.Types.ObjectId;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true })
+  institute: mongoose.Schema.Types.ObjectId;
+
+  /** File URLs stored as an array; the form accepts comma-separated input. */
+  @Prop({ type: [String], default: [] })
+  fileUrls: string[];
+
+  @Prop({ type: Boolean, default: false, index: true })
+  isDeleted: boolean;
+
+  @Prop({ type: Date })
+  deletedAt?: Date;
+}
+
+export const AssignmentSchema = SchemaFactory.createForClass(Assignment);
+
+// Efficient look-ups by subject+package combination
+AssignmentSchema.index({ subject: 1, package: 1 });


### PR DESCRIPTION
Introduce a new Assignments feature: adds AssignmentsModule, controller, service, DTO and Mongoose schema, and registers the module in AppModule. Controller includes authenticated endpoints to create assignments, list by subject+package, and soft-delete by id (uses permission metadata). Service implements create, findBySubjectAndPackage (sorted, excludes soft-deleted), and soft-delete with NotFound handling. Schema defines fields (title, subject, package, institute, fileUrls, isDeleted, deletedAt) and adds an index for subject+package lookups.